### PR TITLE
Add GitHub repo link to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
     <>
     <footer className="flex flex-col items-center justify-center w-full py-6 border-t mt-10 ">
       <div className="text-sm">
-        Made with <span aria-hidden>💜</span> by&nbsp;
+        Made with <span aria-hidden="true">💜</span> by&nbsp;
         <a
           href="https://elimu.ai"
           target="_blank"


### PR DESCRIPTION
## What
Added a link to the GitHub repository in the footer so visitors can easily find the source and contribute.

## Why
Fixes #136 — requested GitHub repo link in the footer for better navigation and transparency.

### Before
<img width="623" height="184" alt="image" src="https://github.com/user-attachments/assets/517be770-cd31-443a-bb4b-d169a6700b5d" />


## Changes
- Updated `components/Footer.tsx`
- Added dynamic © year and GitHub link
- Removed old hardcoded version


### After

<img width="750" height="148" alt="image" src="https://github.com/user-attachments/assets/191452a7-45fb-42df-acea-9568783a2fcb" />


## How to test
1. Run `npm run dev`
2. Visit http://localhost:3000
3. Scroll to footer and verify "Source (GitHub)" opens the repo in a new tab.

Closes #136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added footer links to elimu.ai and source code repository
  * Implemented dynamic copyright year display

* **Style**
  * Restructured footer layout to vertical flex arrangement
  * Added underline styling with hover effects to links

* **Accessibility**
  * Enhanced external links with proper aria-labels
  * Added security attributes to external navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->