### PR TITLE
fix: Configure custom RPC URL #145

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,15 +8,14 @@ import { fallback } from 'viem'
 
 const queryClient = new QueryClient();
 
-const primaryRpcUrl = '/api/rpc'
-const secondaryRpcUrl = 'https://cloudflare-eth.com'
+const fallbackRpcUrl = '/api/rpc'
 
 const config = createConfig({
-  chains: [mainnet], 
+  chains: [mainnet],
   transports: {
     [mainnet.id]: fallback([
-      http(primaryRpcUrl, { batch: true }),
-      http(secondaryRpcUrl, { batch: true })
+      http(mainnet.rpcUrls.default.http[0]),
+      http(fallbackRpcUrl),
     ]),
   },
   connectors: [injected()]


### PR DESCRIPTION
add fallback custom RPC URL : set fallback to a private RPC URL: https://github.com/elimu-ai/web3-liquidity-rewards-ui/issues/145

<img width="1025" height="426" alt="image" src="https://github.com/user-attachments/assets/03a0556b-3cbf-4cc0-957e-b1e0c31aacdf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-side RPC proxy endpoint to relay RPC requests through the app, with request validation and clearer error responses.

* **Refactor**
  * Introduced redundant RPC transport with automatic failover and batched request support to improve reliability and reduce request failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->