### PR TITLE
fix: set custom rpc url

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,7 +10,7 @@ const queryClient = new QueryClient();
 const config = createConfig({
   chains: [mainnet], 
   transports: { 
-    [mainnet.id]: http()
+    [mainnet.id]: http('https://ethereum-rpc.publicnode.com')
   },
   connectors: [injected()]
 })


### PR DESCRIPTION
Because the default wagmi provider is unreliable.

fixes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ethereum mainnet RPC endpoint configuration to enhance network reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->